### PR TITLE
Name Fix: "Unavailiable to Unavailable"

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -104,7 +104,7 @@ x11_symlinks = ["forbidden", "not-allowed"]
 [cursors.dnd_no_drop]
 png = 'dnd_no_drop.png'
 x11_name = 'dnd_no_drop'
-win_name = 'Unavailiable'
+win_name = 'Unavailable'
 x11_symlinks = [
   "03b6e0fcb3499374a867c041f52298f0",
   "circle",


### PR DESCRIPTION
I have a question to you,

Where do i edit the `.inf` file for windows? Because I found lot of errors there, and needs to be fixed immediately.
## Errors & Fixes
### Edit Scheme.Reg
The `scheme.reg` inside `install.inf` should be like this (ignoring the unavailable fix):
```
[Scheme.Reg]
HKCU,"Control Panel\Cursors\Schemes","%SCHEME_NAME%",,"%10%\%CUR_DIR%\%default%,%10%\%CUR_DIR%\%help%,%10%\%CUR_DIR%\%work%,%10%\%CUR_DIR%\%busy%,%10%\%CUR_DIR%\%cross%,%10%\%CUR_DIR%\%ibeam%,%10%\%CUR_DIR%\%handwriting%,%10%\%CUR_DIR%\%unavailiable%,%10%\%CUR_DIR%\%vertical%,%10%\%CUR_DIR%\%horizontal%,%10%\%CUR_DIR%\%diagonal_1%,%10%\%CUR_DIR%\%diagonal_2%,%10%\%CUR_DIR%\%move%,%10%\%CUR_DIR%\%alternate%,%10%\%CUR_DIR%\%link%"
```

### Change Name
Change the name from **BreezeX-RoséPine Cursors** to **Rose Pine**, because this is the issue:

![image](https://github.com/rose-pine/cursor/assets/86149861/42738026-bc07-471a-88ea-34308a6e366a)
