### PR TITLE
Add support for Snap apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ snap install rose-pine-cursor_1.1.0_amd64.snap --dangerous # The --dangerous fla
 
 # Iterates through all installed snap apps on the system, and "plugs in" the rose-pine-cursor snap so that 
 # they can actually read the theme files.
+# Note that you may need to restart these apps or even log out/log back in for the apps to actually pick up the cursor theme.
 for plug in $(snap connections | grep gtk-common-themes:icon-themes | awk '{print $2}'); do sudo snap connect ${plug} rose-pine-cursor:icon-themes; done
 
 # Alternatively, if you'd prefer to test this one app at a time you can run something like this:

--- a/README.md
+++ b/README.md
@@ -84,3 +84,18 @@ bunx cbmp -d 'svg' -n 'BreezeX-RoséPineDawn' -bc '#faf4ed' -oc '#575279'
 ctgen build.toml -d 'bitmaps/BreezeX-RoséPine' -n 'BreezeX-RoséPine' -c 'Rosé Pine BreezeX cursors.'
 ctgen build.toml -d 'bitmaps/BreezeX-RoséPineDawn' -n 'BreezeX-RoséPineDawn' -c 'Rosé Pine Dawn BreezeX cursors.'
 ```
+
+To build and test the snap package locally ensure you have Snapcraft set up by following the instructions [here](https://documentation.ubuntu.com/snapcraft/stable/how-to/set-up-snapcraft/).
+
+Then run the following:
+```sh
+snapcraft
+snap install rose-pine-cursor_1.1.0_amd64.snap --dangerous # The --dangerous flag is required for all snaps that aren't uploaded to the Snap Store
+
+# Iterates through all installed snap apps on the system, and "plugs in" the rose-pine-cursor snap so that 
+# they can actually read the theme files.
+for plug in $(snap connections | grep gtk-common-themes:icon-themes | awk '{print $2}'); do sudo snap connect ${plug} rose-pine-cursor:icon-themes; done
+
+# Alternatively, if you'd prefer to test this one app at a time you can run something like this:
+sudo snap connect firefox:icon-themes rose-pine-cursor:icon-themes
+```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: rose-pine-cursor
+base: core24
+version: '1.1.0'
+title: Rosé Pine Cursor
+summary: Soho vibes for Cursors
+description: |
+  All natural pine, faux fur and a bit of soho vibes for the classy minimalist
+license: GPL-3.0
+website: https://rosepinetheme.com/
+source-code: https://github.com/rose-pine/cursor
+issues: https://github.com/rose-pine/cursor/issues
+
+slots:
+  icon-themes:
+    interface: content
+    source:
+      read:
+        - $SNAP/share/icons/BreezeX-RosePine-Linux
+        - $SNAP/share/icons/BreezeX-RosePineDawn-Linux
+
+grade: stable
+confinement: strict
+
+parts:
+  rose-pine-cursor:
+    plugin: dump
+    build-packages:
+      - pipx
+    source: .
+    override-build: |
+      pipx install clickgen
+      ~/.local/bin/ctgen build.toml -d 'bitmaps/BreezeX-RoséPine' -n 'BreezeX-RoséPine' -c 'Rosé Pine BreezeX cursors.'
+      ~/.local/bin/ctgen build.toml -d 'bitmaps/BreezeX-RoséPineDawn' -n 'BreezeX-RoséPineDawn' -c 'Rosé Pine Dawn BreezeX cursors.'
+      mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+      mv themes/BreezeX-RoséPine $SNAPCRAFT_PART_INSTALL/share/icons/BreezeX-RosePine-Linux
+      mv themes/BreezeX-RoséPineDawn $SNAPCRAFT_PART_INSTALL/share/icons/BreezeX-RosePineDawn-Linux


### PR DESCRIPTION
I've started using Ubuntu more recently, and noticed that the snap apps installed on there weren't picking up this theme because apparently snap apps require themes to exist in their own snap before they can be used :roll_eyes:

Anyway, I wrote up a `snapcraft.yaml` file that will build the cursor theme and package it into a snap that can be plugged into any snap apps you may have so you can have a consistent cursor theme if you're into using snap apps.

In principle we could also publish this to the Snap Store to save people like me a few steps, but I'm not sure what the interest in having that would be so I figured I'd at least open this PR since building and installing the snap isn't too hard and the build file hopefully shouldn't need much maintenance?